### PR TITLE
Add mobile "swipe" support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "detect_swipe"]
+	path = detect_swipe
+	url = https://github.com/marcandre/detect_swipe.git

--- a/README.md
+++ b/README.md
@@ -36,12 +36,27 @@ Turns into this:
 
 ![Navbar Toggle Button](http://groundxaero.github.io/bootstrap-easy-sidebar/readme-images/navbar-button.jpg)
 
+Include the swipe_detect javascript *after* jquery and bootstrap
+````
+<script src="detect_swipe/jquery.detect_swipe.js"></script>  
+````
+
 * At the bottom of your page, before the closing body tag add in this small script
+
 ```javascript
 <script>
 $('.easy-sidebar-toggle').click(function(e) {
 	e.preventDefault();
 	$('body').toggleClass('toggled');
+	$('.navbar.easy-sidebar').removeClass('toggled');
+});
+
+$('body').on('swiperight', function(){
+	$('.navbar.easy-sidebar').addClass('toggled');
+});
+
+$('body').on('swipeleft', function(){
+	$('.navbar.easy-sidebar').removeClass('toggled');
 });
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Turns into this:
 ![Navbar Toggle Button](http://groundxaero.github.io/bootstrap-easy-sidebar/readme-images/navbar-button.jpg)
 
 Include the swipe_detect javascript *after* jquery and bootstrap
-````
+
+````Javascript
 <script src="detect_swipe/jquery.detect_swipe.js"></script>  
 ````
 

--- a/easy-sidebar.css
+++ b/easy-sidebar.css
@@ -1,29 +1,25 @@
 html.easy-sidebar-active {
-	height: 100%;
-	overflow-x: hidden;
-	overflow-y: scroll;
-	margin: 0;
-	padding: 0;
-}
-
-body {
-	transition: 0.2s ease;
-	min-height: 100%;
-	margin: 0;
-	padding: 0;
-}
-body.toggled {
-	-webkit-transform: translateX(250px);
-	transform: translateX(250px);
-}
+		height: 100%;
+		overflow-x: hidden;
+		overflow-y: scroll;
+		margin: 0;
+		padding: 0;
+	}
 
 .navbar.easy-sidebar {
+	transition: 0.2s ease;
 	position: absolute;
 	width: 250px;
 	top: 0;
 	left: -250px;
 	min-height: 100%;
 	border-radius: 0;
+	z-index: 9999;
+}
+
+.navbar.easy-sidebar.toggled {
+	-webkit-transform: translateX(250px);
+	transform: translateX(250px);
 }
 
 .easy-sidebar .btn {
@@ -68,17 +64,7 @@ body.toggled {
 .navbar.easy-sidebar .nav.navbar-nav>li>a {
 	padding: 10px 15px;
 }
-/*
-.navbar.easy-sidebar .navbar-nav .open .dropdown-menu {
-  position: static;
-  float: none;
-  width: auto;
-  margin-top: 0;
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-}
-*/
+
 .navbar.easy-sidebar .navbar-nav .open .dropdown-menu .divider {
   box-shadow: 0 1px 0 rgba(255,255,255, 0.1);
 }
@@ -100,4 +86,27 @@ body.toggled {
 .navbar.easy-sidebar .navbar-form .form-group .form-control {
 	display: block;
 	width: 100%;
+}
+
+@media (min-width:  768px) {
+
+	body {
+		transition: 0.2s ease;
+		min-height: 100%;
+		margin: 0;
+		padding: 0;
+	}
+	body.toggled {
+		-webkit-transform: translateX(250px);
+		transform: translateX(250px);
+	}
+	.navbar.easy-sidebar {
+		transition: 0.2s ease;
+		position: absolute;
+		width: 250px;
+		top: 0;
+		left: -250px;
+		min-height: 100%;
+		border-radius: 0;
+	}
 }

--- a/example.html
+++ b/example.html
@@ -1,0 +1,148 @@
+
+<!DOCTYPE html>
+<html class="easy-sidebar-active">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Bootstrap-Easy-Sidebar</title>
+
+	<script type="text/javascript"></script>
+
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+	<link rel="stylesheet" href="easy-sidebar.css">
+</head>
+
+<body>
+	<body>
+
+	<nav class="navbar navbar-inverse easy-sidebar">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle easy-sidebar-toggle" aria-expanded="false">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<a class="navbar-brand" href="#">Easy-Sidebar</a>
+			</div>
+
+			<ul class="nav navbar-nav">
+				<li class="active"><a href="#">Link <span class="sr-only">(current)</span></a></li>
+				<li><a href="#">Link</a></li>
+				<li class="dropdown">
+					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Dropdown <span class="caret"></span></a>
+					<ul class="dropdown-menu" role="menu">
+						<li><a href="#">Action</a></li>
+						<li><a href="#">Another action</a></li>
+						<li><a href="#">Something else here</a></li>
+						<li class="divider"></li>
+						<li><a href="#">Separated link</a></li>
+						<li class="divider"></li>
+						<li><a href="#">One more separated link</a></li>
+					</ul>
+				</li>
+			</ul>
+			<form class="navbar-form" role="search">
+				<div class="form-group">
+					<input type="text" class="form-control" placeholder="Search">
+				</div>
+				<button type="submit" class="btn btn-default">Submit</button>
+			</form>
+			<ul class="nav navbar-nav">
+				<li><a href="#">Link</a></li>
+			</ul>
+		</div>
+	</nav>
+
+	<nav class="navbar navbar-default">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-2" aria-expanded="false">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<a class="navbar-brand" href="#">Easy-Sidebar</a>
+			</div>
+
+			<div class="navbar-collapse collapse" id="bs-example-navbar-collapse-2" aria-expanded="false" style="height: 1px;">
+				<ul class="nav navbar-nav">
+					<li class="active"><a href="#">Link <span class="sr-only">(current)</span></a></li>
+					<li><a href="#">Link</a></li>
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Dropdown <span class="caret"></span></a>
+						<ul class="dropdown-menu" role="menu">
+							<li><a href="#">Action</a></li>
+							<li><a href="#">Another action</a></li>
+							<li><a href="#">Something else here</a></li>
+							<li class="divider"></li>
+							<li><a href="#">Separated link</a></li>
+							<li class="divider"></li>
+							<li><a href="#">One more separated link</a></li>
+						</ul>
+					</li>
+				</ul>
+				<form class="navbar-form navbar-left" role="search">
+					<div class="form-group">
+						<input type="text" class="form-control" placeholder="Search">
+					</div>
+					<button type="submit" class="btn btn-default">Submit</button>
+				</form>
+				<ul class="nav navbar-nav navbar-right">
+					<li><a href="#">Link</a></li>
+				</ul>
+			</div>
+		</div>
+	</nav>
+
+	<div id="content" class="container">
+
+		<h1>Testing</h1>
+
+		<button class="btn easy-sidebar-toggle">Toggle Sidebar</button>
+
+		<div class="table-responsive">
+			<table class="table table-hover">
+				<caption>table title and/or explanatory text</caption>
+				<thead>
+					<tr>
+						<th>header</th>
+						<th>header2</th>
+						<th>header3</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>data</td>
+						<td>data2</td>
+						<td>data3</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+	</div>
+
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+	<script src="detect_swipe/jquery.detect_swipe.js"></script>
+	<!-- Menu Toggle Script -->
+	<script>
+		$('.easy-sidebar-toggle').click(function(e) {
+			e.preventDefault();
+			$('body').toggleClass('toggled');
+			$('.navbar.easy-sidebar').removeClass('toggled');
+		});
+
+		$('body').on('swiperight', function(){
+			$('.navbar.easy-sidebar').addClass('toggled');
+		});
+
+		$('body').on('swipeleft', function(){
+			$('.navbar.easy-sidebar').removeClass('toggled');
+		});
+	</script>
+</body>


### PR DESCRIPTION
I've used the jquery.swipe_detect plugin to add mobile "swipe out" support to the sidebar. I had to change the style slightly so that the menu overlays the main content on mobile devices (thus the media query in the css) I also added an example file (based on the demo) to the repository to make testing easier.

This example places the swipe detection on the body tag, it may be better to use in on the html tag as the body is not always 100% of the viewport height (and isn't in this example file!)
